### PR TITLE
Replace patchConstructorImpl with a returning bound constructor

### DIFF
--- a/cosmoz-templatizer.html
+++ b/cosmoz-templatizer.html
@@ -33,28 +33,13 @@
 			}
 
 			this.dataHost = owner;
-			this._patchConstructorImpl();
+
 			Polymer.Templatizer.templatize.call(this, template);
 			template.__templatizer = this;
 
-			return this.ctor;
-		},
-
-		_patchConstructorImpl() {
-			let _ctor  = this._constructorImpl,
-				self = this;
-
-			this._constructorImpl = function (model = {}, host = self) {
-				if (self._parentProps) {
-					var templatized = self._templatized;
-					for (let prop in self._parentProps) {
-						if (model[prop] === undefined) {
-							model[prop] = templatized[self._parentPropPrefix + prop];
-						}
-					}
-				}
-				return _ctor.call(this, model, host);
-			};
+			return (function (self, model){
+				return self.stamp(model);
+			}).bind(null, this);
 		},
 
 		_getRootDataHost() {

--- a/cosmoz-templatizer.html
+++ b/cosmoz-templatizer.html
@@ -8,9 +8,14 @@
 			Polymer.Templatizer
 		],
 		templatize(template, owner, opts = {}) {
+			const ctor =  (function (self, model){
+				return self.stamp(model);
+			}).bind(null, this);
+
 			if (this.ctor) {
-				return this.ctor;
+				return ctor;
 			}
+
 			this.__owner = owner;
 			this._instanceProps = opts.instanceProps;
 
@@ -37,9 +42,7 @@
 			Polymer.Templatizer.templatize.call(this, template);
 			template.__templatizer = this;
 
-			return (function (self, model){
-				return self.stamp(model);
-			}).bind(null, this);
+			return ctor;
 		},
 
 		_getRootDataHost() {


### PR DESCRIPTION
Replace `patchConstructorImpl` with a returning bound constructor that calls `stamp`.
fixes Neovici/cosmoz-dialog#19 